### PR TITLE
Make lastConnected optional in DTO

### DIFF
--- a/libs/python/starlink-client/starlink_client/dto.py
+++ b/libs/python/starlink-client/starlink_client/dto.py
@@ -77,7 +77,7 @@ class UserTerminal(BaseModel):
     active: bool
     configId: Optional[str] = None
     nickname: Optional[str] = None
-    lastConnected: datetime
+    lastConnected: Optional[datetime] = None
     lastDisconnected: Optional[datetime] = None
     routers: List[Router]
     isOffline: Optional[bool] = None


### PR DESCRIPTION
the lastConnected parameter is not always set. It will be null if this is a new terminal that's never been turned on yet.