### PR TITLE
fix(python): remove stale XSRF-TOKEN check, make Router fields optional

### DIFF
--- a/libs/python/starlink-client/starlink_client/dto.py
+++ b/libs/python/starlink-client/starlink_client/dto.py
@@ -51,7 +51,7 @@ class Subscription(BaseModel):
 
 class Router(BaseModel):
     routerId: str
-    accountNumber: str
+    accountNumber: Optional[str] = None
     userTerminalId: str
     nickname: Optional[str] = None
     lastConnected: datetime
@@ -60,7 +60,7 @@ class Router(BaseModel):
     isBypassed: bool
     configId: Optional[str] = None
     directLinkToDish: bool
-    hardwareVersion: str
+    hardwareVersion: Optional[str] = None
 
     def get_id(self) -> str:
         return f"Router-{self.routerId}"

--- a/libs/python/starlink-client/starlink_client/grpc_web_base_client.py
+++ b/libs/python/starlink-client/starlink_client/grpc_web_base_client.py
@@ -306,9 +306,6 @@ class GrpcWebBaseClient:
                 )
 
             self._xsrf_token = self._cookie_jar.get("XSRF-TOKEN", "")
-
-            if not self._xsrf_token:
-                raise AuthenticationError("Failed to retrieve XSRF token")
         # Actualizar la cadena de cookies a partir del cookie jar
         self._update_cookie_header()
         return True


### PR DESCRIPTION
## Summary
- **Remove XSRF-TOKEN hard requirement in `_refresh_auth`**: Starlink's auth endpoint (`api.starlink.com/auth-rp/auth/user`) no longer returns an `XSRF-TOKEN` cookie. Auth succeeds (HTTP 200 + valid account JSON + refreshed `Starlink.Com.Access.V1` cookie), but the client raises `AuthenticationError("Failed to retrieve XSRF token")` because of this check. The token is still read and used if present — just no longer required.
- **Make `Router.accountNumber` and `Router.hardwareVersion` optional**: The API returns `null` for these fields on some router configurations (tested with Starlink Router v4 + Mini dish, firmware `2026.03.05.mr72456`), causing a Pydantic `ValidationError`.

## Test plan
- [x] Tested with real Starlink account (Mini dish + Router v4 in Spain)
- [x] `list_devices.py` runs successfully after both fixes: lists dish, router, WiFi networks, connected clients
- [x] Auth refresh works — new `Starlink.Com.Access.V1` cookie returned and stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)